### PR TITLE
Corrects Input's tags

### DIFF
--- a/src/c/libraries/alynne/input.md
+++ b/src/c/libraries/alynne/input.md
@@ -4,9 +4,8 @@ description: Comprehensive cross-platform input for GameMaker 2022 LTS
 link: https://github.com/offalynne/Input
 date: 2024-03-08 03:00:00
 tags:
-  - i18n
-  - text
-  - dialogue
+  - input
+  - gamepad
   - lts
 authors:
   - offalynne


### PR DESCRIPTION
The Input library had tags copied over from Scribble. This PR changes incorrect tags `i18n` `text` `dialogue` to `input` `gamepad`.