### PR TITLE
Center items in the navbar, including the theme-switcher button

### DIFF
--- a/src/_includes/css/navbar.css
+++ b/src/_includes/css/navbar.css
@@ -2,6 +2,7 @@
   border-bottom: 1px dashed var(--lightgray);
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
 
   & a {
     padding: 1em;


### PR DESCRIPTION
Resolves issue #222 