### PR TITLE
Put link before tags & publish date on resource pages

### DIFF
--- a/src/_includes/css/post.css
+++ b/src/_includes/css/post.css
@@ -11,6 +11,10 @@
 .post-tags {
   display: inline;
 }
+.post-link {
+  display: block;
+  line-height: 2;
+}
 .post-body {
   font-size: 1.2em;
   line-height: 1.4;

--- a/src/_includes/layouts/resource.njk
+++ b/src/_includes/layouts/resource.njk
@@ -21,6 +21,11 @@ bodyClass: body-post
 	</nav>
 	</h2>
 	
+	{% if link and link != "N/A" %}
+	<div class="post-link">
+		<a href="{{ link }}" target="_blank">Link to {{ title }}</a>
+	</div>
+	{% endif %}
 
     <nav class="post-tags">
     {% for tag in tags %}
@@ -31,10 +36,6 @@ bodyClass: body-post
 	<time class="post-date" datetime="{{ date | date('DATETIME') }}">
 		{{ date | date('HUMAN_DATE') }} 
 	</time>
-	
-	{% if link and link != "N/A" %}
-		<br><a href="{{ link }}" target="_blank">Link to {{ title }}</a>
-	{% endif %}
 	
 	<!-- GM Version -->
 	{% if gm_versions %}


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/7719dc83-28aa-48f9-ae73-03b06eff6556) | ![image](https://github.com/user-attachments/assets/233e6f1c-70b5-4610-ad73-d58da7ee792f) |

Visually flows a bit more nicely.