### PR TITLE
Nicer vertical spacing in the tag list

### DIFF
--- a/src/tags.njk
+++ b/src/tags.njk
@@ -8,6 +8,9 @@ footerMenu:
   order: 1
 ---
 <h1>Tags</h1>
-{% for page in search.pages("type=tag", "tag") %}
-  <a href="{{ page.data.url }}" class="tag is-big">{{ page.data.tag }}</a>
-{% endfor %}
+
+<div class="block-tag-list">
+  {% for page in search.pages("type=tag", "tag") %}
+	  <a href="{{ page.data.url }}" class="tag is-big">{{ page.data.tag }}</a>
+	{% endfor %}
+</div>


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/39116a7c-9cf7-4794-9d5d-ec16f77b7452) | ![image](https://github.com/user-attachments/assets/d7106f66-a910-4044-9e9a-0c857e588e1f) |

Same treatment for the tags page as the authors page, I didn't notice that page lol