### PR TITLE
Adds InputTouch to GameMaker Kitchen website

### DIFF
--- a/src/plugins/alubj/inputtouch.md
+++ b/src/plugins/alubj/inputtouch.md
@@ -1,0 +1,19 @@
+---
+title: InputTouch
+description: Touch based input plug-In for Input
+link: https://github.com/AlubJ/InputTouch
+date: 2026-06-29 14:26:00
+parent: Input
+tags:
+  - Input
+  - Touch
+  - Mobile
+  - Input-plugin
+authors:
+  - AlubJ
+---
+InputTouch is a plug-in for [Input](https://codeberg.org/offalynne/Input) 10.3+ which handles touch based inputs. Touch, multi-touch, gestures and device vibration (using YoYo Games' [MobileUtils](https://github.com/YoYoGames/GMEXT-MobileUtils) extension) are all supported.
+
+- [Read the docs](https://docs.alub.dev/InputTouch)
+- [Download latest .yymps](https://github.com/AlubJ/InputTouch/releases/latest)
+- [MIT License](https://github.com/AlubJ/InputTouch/blob/main/LICENSE)


### PR DESCRIPTION
This pull request adds my InputTouch plug-in to the GameMaker Kitchen website. This adds a new markdown file for the plug-in. The [docs for Input](https://offalynne.grebedoc.dev/Input/#/10.3/Plug-ins) includes a link to the GameMaker Kitchen website and thus InputMobile feels appropriate to be on there.